### PR TITLE
Unit tests and AX

### DIFF
--- a/mellophone/frontend/src/App.tsx
+++ b/mellophone/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useContext } from "react";
+import React from "react";
 import { Router } from "@reach/router";
 import { autorun } from "mobx";
 import { observer } from "mobx-react-lite";
@@ -22,21 +22,21 @@ import PageNotFound from "./pages/PageNotFound";
 import CreateTeam from "./pages/CreateTeam";
 
 function App() {
-  const [userPending, setUserPending] = useState(true);
-  const [stores] = useState({
+  const [userPending, setUserPending] = React.useState(true);
+  const [stores] = React.useState({
     sessionStore: new SessionStore(),
     teamStore: new TeamStore(),
   });
-  const { getSessionUser } = useContext(NetworkContext);
+  const { getSessionUser } = React.useContext(NetworkContext);
 
-  useEffect(() => {
+  React.useEffect(() => {
     getSessionUser()
       .then(user => user && stores.sessionStore.signIn(user))
       .catch(console.error)
       .finally(() => setUserPending(false));
   }, [stores, getSessionUser]);
 
-  useEffect(
+  React.useEffect(
     () =>
       // If a user signs out, clear their teams
       autorun(() => {

--- a/mellophone/frontend/src/elements/Main.tsx
+++ b/mellophone/frontend/src/elements/Main.tsx
@@ -20,7 +20,7 @@ interface Props {
  */
 function Main(props: Props) {
   return (
-    <main className={classnames(classes.main, props.className)}>
+    <main role="main" className={classnames(classes.main, props.className)}>
       {props.children}
     </main>
   );

--- a/mellophone/frontend/src/network/meetingService.ts
+++ b/mellophone/frontend/src/network/meetingService.ts
@@ -1,10 +1,11 @@
-import { IMeeting, IMeetingToBeCreated } from "../types";
+import { IMeeting } from "../types";
 import BaseRequest from "../utils/BaseRequest";
 
 export interface IMeetingService {
   createMeeting(
-    meeting: IMeetingToBeCreated,
-    teamId: number
+    teamId: number,
+    name: string,
+    venue?: string
   ): Promise<IMeeting>;
   getMeetingById(meetingId: number): Promise<IMeeting>;
   getMeetingsOfTeam(teamId: number): Promise<IMeeting[]>;
@@ -12,15 +13,16 @@ export interface IMeetingService {
 
 export default {
   async createMeeting(
-    meeting: IMeetingToBeCreated,
-    teamId: number
+    teamId: number,
+    name: string,
+    venue?: string
   ): Promise<IMeeting> {
-    if (!meeting.name) {
+    if (!name) {
       throw new Error("Meetings must have a name");
     }
     const response = await BaseRequest.post<{ meeting: IMeeting }>(
       `/teams/${teamId}/meetings`,
-      meeting
+      { name, venue }
     );
     return response.meeting;
   },

--- a/mellophone/frontend/src/pages/CreateMeeting.tsx
+++ b/mellophone/frontend/src/pages/CreateMeeting.tsx
@@ -1,29 +1,29 @@
-import React from "react";
+import React, { useContext } from "react";
 import { RouteComponentProps } from "@reach/router";
 
 import Main from "../elements/Main";
 import Route from "../utils/Route";
-import { IMeetingToBeCreated } from "../types";
-import meetingService from "../network/meetingService";
 import CreateMeetingForm from "../sections/CreateMeetingForm";
 import requireAuthentication from "../utils/requireAuthentication";
+import { NetworkContext } from "../network";
 
 function CreateMeeting(props: RouteComponentProps<{ teamId: string }>) {
-  const teamId = Number(props.teamId).valueOf();
+  const { createMeeting } = useContext(NetworkContext);
+  const teamId = Number(props.teamId);
 
-  if (Number.isNaN(teamId)) return null;
-
-  const createMeeting = async (meeting: IMeetingToBeCreated) => {
-    const meetingId = (await meetingService.createMeeting(meeting, teamId)).id;
+  const onCreateMeeting = async (name: string, venue?: string) => {
+    const meetingId = (await createMeeting(teamId, name, venue)).id;
     new Route(Route.MEETINGS, meetingId).navigate();
   };
 
   return (
     <Main>
       <h1>Create a meeting</h1>
-      <CreateMeetingForm createMeeting={createMeeting} />
+      <CreateMeetingForm createMeeting={onCreateMeeting} />
     </Main>
   );
 }
 
-export default requireAuthentication(CreateMeeting);
+export default requireAuthentication<RouteComponentProps<{ teamId: string }>>(
+  CreateMeeting
+);

--- a/mellophone/frontend/src/pages/CreateMeeting.tsx
+++ b/mellophone/frontend/src/pages/CreateMeeting.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import React from "react";
 import { RouteComponentProps } from "@reach/router";
 
 import Main from "../elements/Main";
@@ -8,7 +8,7 @@ import requireAuthentication from "../utils/requireAuthentication";
 import { NetworkContext } from "../network";
 
 function CreateMeeting(props: RouteComponentProps<{ teamId: string }>) {
-  const { createMeeting } = useContext(NetworkContext);
+  const { createMeeting } = React.useContext(NetworkContext);
   const teamId = Number(props.teamId);
 
   const onCreateMeeting = async (name: string, venue?: string) => {

--- a/mellophone/frontend/src/pages/CreateMeeting.tsx
+++ b/mellophone/frontend/src/pages/CreateMeeting.tsx
@@ -20,7 +20,7 @@ function CreateMeeting(props: RouteComponentProps<{ teamId: string }>) {
 
   return (
     <Main>
-      <h2>Create meeting</h2>
+      <h1>Create a meeting</h1>
       <CreateMeetingForm createMeeting={createMeeting} />
     </Main>
   );

--- a/mellophone/frontend/src/pages/CreateTeam.tsx
+++ b/mellophone/frontend/src/pages/CreateTeam.tsx
@@ -21,7 +21,7 @@ function CreateTeam(_: RouteComponentProps) {
 
   return (
     <Main>
-      <h2>Create a new team</h2>
+      <h1>Create a new team</h1>
       <CreateTeamForm createTeam={createTeam} />
     </Main>
   );

--- a/mellophone/frontend/src/pages/Home.tsx
+++ b/mellophone/frontend/src/pages/Home.tsx
@@ -38,7 +38,7 @@ function Home(_: RouteComponentProps) {
 
 function SplashPage() {
   return (
-    <div className={classes.splash}>
+    <Main className={classes.splash}>
       <div className={classes.cards}>
         <div
           style={{
@@ -77,7 +77,7 @@ function SplashPage() {
           <Link to={new Route(Route.SIGN_IN).build()}>Sign up!</Link>
         </h2>
       </div>
-    </div>
+    </Main>
   );
 }
 

--- a/mellophone/frontend/src/pages/Meeting.tsx
+++ b/mellophone/frontend/src/pages/Meeting.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useContext } from "react";
+import React from "react";
 import { RouteComponentProps } from "@reach/router";
 
 import { IMeeting } from "../types";
@@ -11,9 +11,9 @@ import ErrorMessage from "../elements/ErrorMessage";
 type Props = RouteComponentProps<{ meetingId: string }>;
 
 function Meeting(props: Props) {
-  const [meeting, setMeeting] = useState<IMeeting>();
-  const [error, setError] = useState<Error>();
-  const { getMeetingById } = useContext(NetworkContext);
+  const [meeting, setMeeting] = React.useState<IMeeting>();
+  const [error, setError] = React.useState<Error>();
+  const { getMeetingById } = React.useContext(NetworkContext);
 
   const meetingId = Number(props.meetingId);
 

--- a/mellophone/frontend/src/pages/SignIn.tsx
+++ b/mellophone/frontend/src/pages/SignIn.tsx
@@ -54,9 +54,9 @@ function SignIn(_: RouteComponentProps) {
 
   return (
     <Main className={classes.formContainer}>
-      <h2 className={classes.title}>
+      <h1 className={classes.title}>
         {newAccount ? "Sign up to Mellophone" : "Sign in to Mellophone"}
-      </h2>
+      </h1>
 
       {newAccount ? (
         <SignUpForm signUp={onSignUp} />

--- a/mellophone/frontend/src/pages/Team.tsx
+++ b/mellophone/frontend/src/pages/Team.tsx
@@ -13,12 +13,14 @@ import { StoresContext } from "../stores";
 import { NetworkContext } from "../network";
 import requireAuthentication from "../utils/requireAuthentication";
 
-function Team(props: RouteComponentProps<{ teamId: string }>) {
+type Props = RouteComponentProps<{ teamId: string }>;
+
+function Team(props: Props) {
   const [meetings, setMeetings] = React.useState<IMeeting[]>();
   const { teamStore } = React.useContext(StoresContext);
   const { getTeamById } = React.useContext(NetworkContext);
 
-  const teamId = Number(props.teamId).valueOf();
+  const teamId = Number(props.teamId);
 
   React.useEffect(() => {
     if (!Number.isNaN(teamId)) {
@@ -33,7 +35,7 @@ function Team(props: RouteComponentProps<{ teamId: string }>) {
   const team = teamStore.teams.get(teamId);
   return (
     <Main>
-      <TeamProfile team={team} />
+      {team && <TeamProfile team={team} />}
       <Button
         onClick={() =>
           new Route(Route.TEAMS, teamId, Route.MEETINGS, Route.NEW).navigate()
@@ -41,9 +43,9 @@ function Team(props: RouteComponentProps<{ teamId: string }>) {
         Create meeting
       </Button>
       <hr style={{ margin: "1rem 0" }} />
-      <MeetingList meetings={meetings} />
+      {meetings && <MeetingList meetings={meetings} />}
     </Main>
   );
 }
 
-export default requireAuthentication(observer(Team));
+export default requireAuthentication<Props>(observer(Team));

--- a/mellophone/frontend/src/pages/Team.tsx
+++ b/mellophone/frontend/src/pages/Team.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useContext, useEffect } from "react";
+import React from "react";
 import { RouteComponentProps } from "@reach/router";
 import { observer } from "mobx-react-lite";
 
@@ -16,14 +16,14 @@ import ErrorMessage from "../elements/ErrorMessage";
 type Props = RouteComponentProps<{ teamId: string }>;
 
 function Team(props: Props) {
-  const [error, setError] = useState<Error>();
-  const [meetings, setMeetings] = useState<IMeeting[]>();
-  const { teamStore } = useContext(StoresContext);
-  const { getTeamById, getMeetingsOfTeam } = useContext(NetworkContext);
+  const [error, setError] = React.useState<Error>();
+  const [meetings, setMeetings] = React.useState<IMeeting[]>();
+  const { teamStore } = React.useContext(StoresContext);
+  const { getTeamById, getMeetingsOfTeam } = React.useContext(NetworkContext);
 
   const teamId = Number(props.teamId);
 
-  useEffect(() => {
+  React.useEffect(() => {
     if (!Number.isNaN(teamId)) {
       getTeamById(teamId)
         .then(team => {

--- a/mellophone/frontend/src/pages/Team.tsx
+++ b/mellophone/frontend/src/pages/Team.tsx
@@ -1,40 +1,46 @@
-import React from "react";
+import React, { useState, useContext, useEffect } from "react";
 import { RouteComponentProps } from "@reach/router";
 import { observer } from "mobx-react-lite";
 
 import Main from "../elements/Main";
 import TeamProfile from "../sections/TeamProfile";
 import MeetingList from "../sections/MeetingList";
-import meetingService from "../network/meetingService";
 import { IMeeting } from "../types";
 import Button from "../elements/Button";
 import Route from "../utils/Route";
 import { StoresContext } from "../stores";
 import { NetworkContext } from "../network";
 import requireAuthentication from "../utils/requireAuthentication";
+import ErrorMessage from "../elements/ErrorMessage";
 
 type Props = RouteComponentProps<{ teamId: string }>;
 
 function Team(props: Props) {
-  const [meetings, setMeetings] = React.useState<IMeeting[]>();
-  const { teamStore } = React.useContext(StoresContext);
-  const { getTeamById } = React.useContext(NetworkContext);
+  const [error, setError] = useState<Error>();
+  const [meetings, setMeetings] = useState<IMeeting[]>();
+  const { teamStore } = useContext(StoresContext);
+  const { getTeamById, getMeetingsOfTeam } = useContext(NetworkContext);
 
   const teamId = Number(props.teamId);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (!Number.isNaN(teamId)) {
-      getTeamById(teamId).then(team => {
-        teamStore.addTeam(team);
-        teamStore.addToSessionUserTeams(team.id);
-      });
-      meetingService.getMeetingsOfTeam(teamId).then(setMeetings);
+      getTeamById(teamId)
+        .then(team => {
+          teamStore.addTeam(team);
+          teamStore.addToSessionUserTeams(team.id);
+        })
+        .catch(setError);
+      getMeetingsOfTeam(teamId)
+        .then(setMeetings)
+        .catch(setError);
     }
-  }, [teamId, teamStore, getTeamById]);
+  }, [teamId, teamStore, getTeamById, getMeetingsOfTeam]);
 
   const team = teamStore.teams.get(teamId);
   return (
     <Main>
+      <ErrorMessage error={error} />
       {team && <TeamProfile team={team} />}
       <Button
         onClick={() =>

--- a/mellophone/frontend/src/pages/__tests__/CreateMeeting.spec.tsx
+++ b/mellophone/frontend/src/pages/__tests__/CreateMeeting.spec.tsx
@@ -1,0 +1,87 @@
+import React from "react";
+
+import CreateMeeting from "../CreateMeeting";
+import TestRenderer from "../../utils/TestRenderer";
+import mock from "../../utils/mock";
+import { fireEvent, wait, cleanup } from "@testing-library/react";
+import SessionStore from "../../stores/SessionStore";
+import { navigate } from "@reach/router";
+
+beforeEach(() => {
+  cleanup();
+  navigate("/");
+});
+
+it("Does not render when a user is not authenticated", () => {
+  const { container } = new TestRenderer().render(<CreateMeeting />);
+
+  expect(container.childElementCount).toBe(0);
+});
+
+it("Allows teams to create a meeting", async () => {
+  const sessionStore = new SessionStore();
+  sessionStore.signIn(mock.user());
+  const meeting = mock.meeting();
+  const teamId = 20;
+  const createMeeting = jest.fn(async () => meeting);
+  const { getByLabelText, getByText } = new TestRenderer()
+    .withNetwork({ createMeeting })
+    .withStores({ sessionStore })
+    .render(<CreateMeeting teamId={teamId.toString()} />);
+
+  fireEvent.input(getByLabelText("Meeting name"), {
+    target: { value: meeting.name },
+  });
+  fireEvent.input(getByLabelText("Venue (optional)"), {
+    target: { value: meeting.venue },
+  });
+  fireEvent.click(getByText("Create meeting"));
+
+  await wait(() =>
+    expect(window.location.pathname).toMatch(meeting.id.toString())
+  );
+  expect(createMeeting).toBeCalledTimes(1);
+  expect(createMeeting).toBeCalledWith(teamId, meeting.name, meeting.venue);
+});
+
+it("Allows teams to create a meeting without specifying a venue", async () => {
+  const sessionStore = new SessionStore();
+  sessionStore.signIn(mock.user());
+  const meeting = mock.meeting();
+  const teamId = 21;
+  const createMeeting = jest.fn(async () => meeting);
+  const { getByLabelText, getByText } = new TestRenderer()
+    .withNetwork({ createMeeting })
+    .withStores({ sessionStore })
+    .render(<CreateMeeting teamId={teamId.toString()} />);
+
+  fireEvent.input(getByLabelText("Meeting name"), {
+    target: { value: meeting.name },
+  });
+  fireEvent.click(getByText("Create meeting"));
+
+  await wait(() =>
+    expect(window.location.pathname).toMatch(meeting.id.toString())
+  );
+  expect(createMeeting).toBeCalledTimes(1);
+  expect(createMeeting).toBeCalledWith(teamId, meeting.name, "");
+});
+
+it("Shows a error message when creating a team fails", async () => {
+  const sessionStore = new SessionStore();
+  sessionStore.signIn(mock.user());
+  const createMeeting = jest.fn(async () => {
+    throw new Error("This is an error message");
+  });
+  const { getByText, queryByText } = new TestRenderer()
+    .withStores({ sessionStore })
+    .withNetwork({ createMeeting })
+    .render(<CreateMeeting teamId="1" />);
+
+  fireEvent.click(getByText("Create meeting"));
+
+  await wait(() =>
+    expect(queryByText("This is an error message")).not.toBe(null)
+  );
+  expect(createMeeting).toBeCalledTimes(1);
+});

--- a/mellophone/frontend/src/pages/__tests__/CreateTeam.spec.tsx
+++ b/mellophone/frontend/src/pages/__tests__/CreateTeam.spec.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { render, fireEvent, wait, cleanup } from "@testing-library/react";
 import { navigate } from "@reach/router";
-import { observable } from "mobx";
 
 import CreateTeam from "../CreateTeam";
 import TestRenderer from "../../utils/TestRenderer";

--- a/mellophone/frontend/src/pages/__tests__/Meeting.spec.tsx
+++ b/mellophone/frontend/src/pages/__tests__/Meeting.spec.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { wait, cleanup } from "@testing-library/react";
+
+import Meeting from "../Meeting";
+import TestRenderer from "../../utils/TestRenderer";
+import SessionStore from "../../stores/SessionStore";
+import mock from "../../utils/mock";
+
+beforeEach(cleanup);
+
+it("Does not render when a user is not authenticated", () => {
+  const { container } = new TestRenderer().render(<Meeting />);
+
+  expect(container.childElementCount).toBe(0);
+});
+
+it("Shows an error message when a meeting cannot be loaded", async () => {
+  const sessionStore = new SessionStore();
+  sessionStore.signIn(mock.user());
+  const getMeetingById = jest.fn(async () => {
+    throw new Error("An error message goes here.");
+  });
+  const { queryByText } = new TestRenderer()
+    .withStores({ sessionStore })
+    .withNetwork({ getMeetingById })
+    .render(<Meeting meetingId="1" />);
+
+  await wait(() =>
+    expect(queryByText("An error message goes here.")).not.toBe(null)
+  );
+  expect(getMeetingById).toBeCalledTimes(1);
+});
+
+it("Shows a meeting when it is loaded", async () => {
+  const sessionStore = new SessionStore();
+  sessionStore.signIn(mock.user());
+  const meeting = mock.meeting();
+  const getMeetingById = jest.fn(async () => meeting);
+  const { queryByText } = new TestRenderer()
+    .withStores({ sessionStore })
+    .withNetwork({ getMeetingById })
+    .render(<Meeting meetingId={meeting.id.toString()} />);
+
+  await wait(() => expect(queryByText(meeting.name)).not.toBe(null));
+  expect(getMeetingById).toBeCalledTimes(1);
+  expect(getMeetingById).toBeCalledWith(meeting.id);
+});

--- a/mellophone/frontend/src/pages/__tests__/Team.spec.tsx
+++ b/mellophone/frontend/src/pages/__tests__/Team.spec.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { wait } from "@testing-library/react";
+
+import Team from "../Team";
+import TestRenderer from "../../utils/TestRenderer";
+import SessionStore from "../../stores/SessionStore";
+import mock from "../../utils/mock";
+
+it("Renders nothing when no user is authenticated", () => {
+  const { container } = new TestRenderer().render(<Team />);
+
+  expect(container.childElementCount).toBe(0);
+});
+
+it("Renders the team with the specified ID and its meetings", async () => {
+  const sessionStore = new SessionStore();
+  sessionStore.signIn(mock.user());
+  const team = mock.team();
+  const getTeamById = jest.fn(async () => team);
+  const meeting = mock.meeting({ team });
+  const getMeetingsOfTeam = jest.fn(async () => [meeting]);
+  const { queryByText } = new TestRenderer()
+    .withNetwork({ getTeamById, getMeetingsOfTeam })
+    .withStores({ sessionStore })
+    .render(<Team teamId={team.id.toString()} />);
+
+  await wait(() => expect(queryByText(team.name)).not.toBe(null));
+  expect(getTeamById).toBeCalledTimes(1);
+  expect(getTeamById).toBeCalledWith(team.id);
+  await wait(() => expect(queryByText(meeting.name)).not.toBe(null));
+  expect(getMeetingsOfTeam).toBeCalledTimes(1);
+  expect(getMeetingsOfTeam).toBeCalledWith(team.id);
+});
+
+it("Displays an error message when fetching some page content fails", async () => {
+  const sessionStore = new SessionStore();
+  sessionStore.signIn(mock.user());
+  const team = mock.team();
+  const getTeamById = jest.fn(async () => team);
+  const message = "Something went wrong while fetching the meetings";
+  const getMeetingsOfTeam = jest.fn(async () => {
+    throw new Error(message);
+  });
+  const { queryByText } = new TestRenderer()
+    .withNetwork({ getTeamById, getMeetingsOfTeam })
+    .withStores({ sessionStore })
+    .render(<Team teamId={team.id.toString()} />);
+
+  await wait(() => expect(queryByText(message)).not.toBe(null));
+});

--- a/mellophone/frontend/src/sections/AccountBlock.tsx
+++ b/mellophone/frontend/src/sections/AccountBlock.tsx
@@ -34,9 +34,9 @@ function AccountBlock(props: Props) {
       </div>
 
       <div className={classes.textContainer}>
-        <h2>
+        <h1>
           {user.firstName} {user.lastName}
-        </h2>
+        </h1>
         <p>{user.email}</p>
         <p>User #{user.id} of Mellophone!</p>
         <Button className={classes.button} onClick={onSignOut}>

--- a/mellophone/frontend/src/sections/CreateMeetingForm.tsx
+++ b/mellophone/frontend/src/sections/CreateMeetingForm.tsx
@@ -1,14 +1,13 @@
 import React from "react";
 import { observer } from "mobx-react-lite";
 
-import { IMeetingToBeCreated } from "../types";
 import classes from "./CreateMeetingForm.module.css";
 import Input from "../elements/Input";
 import Button from "../elements/Button";
 import ErrorMessage from "../elements/ErrorMessage";
 
 interface Props {
-  createMeeting: (meeting: IMeetingToBeCreated) => Promise<void>;
+  createMeeting: (name: string, venue?: string) => Promise<void>;
 }
 
 function CreateTeamForm(props: Props) {
@@ -20,12 +19,7 @@ function CreateTeamForm(props: Props) {
     const name = nameRef.current;
     const venue = venueRef.current;
     if (name && venue) {
-      props
-        .createMeeting({
-          name: name.value,
-          venue: venue.value,
-        })
-        .catch(setError);
+      props.createMeeting(name.value, venue.value).catch(setError);
     }
   };
 

--- a/mellophone/frontend/src/sections/MeetingDocument.tsx
+++ b/mellophone/frontend/src/sections/MeetingDocument.tsx
@@ -14,13 +14,13 @@ function MeetingDocument(props: Props) {
 
   return (
     <div>
-      <h2>{meeting.name}</h2>
-      <h3>
+      <h1>{meeting.name}</h1>
+      <h2>
         Meeting held {meeting.dateHeld.toString()} by{" "}
         <Link to={new Route(Route.TEAMS, meeting.team.id).build()}>
           {meeting.team.name}
         </Link>
-      </h3>
+      </h2>
       <p>
         <em>Yesterday, all my problems seemed so far away...</em>
       </p>

--- a/mellophone/frontend/src/sections/MeetingList.tsx
+++ b/mellophone/frontend/src/sections/MeetingList.tsx
@@ -6,12 +6,10 @@ import Route from "../utils/Route";
 import { observer } from "mobx-react-lite";
 
 interface Props {
-  meetings?: IMeeting[];
+  meetings: IMeeting[];
 }
 
 function MeetingList(props: Props) {
-  if (!props.meetings) return null;
-
   return (
     <>
       <h3>Meetings</h3>

--- a/mellophone/frontend/src/sections/TeamList.tsx
+++ b/mellophone/frontend/src/sections/TeamList.tsx
@@ -14,7 +14,7 @@ interface Props {
 function TeamList({ teams }: Props) {
   return (
     <div className={classes.container}>
-      <h2>My teams</h2>
+      <h1>My teams</h1>
 
       {teams.map(team => (
         <div key={team.id} className={classes.team}>

--- a/mellophone/frontend/src/sections/TeamProfile.tsx
+++ b/mellophone/frontend/src/sections/TeamProfile.tsx
@@ -4,12 +4,10 @@ import { observer } from "mobx-react-lite";
 import { ITeam } from "../types";
 
 interface Props {
-  team: ITeam | undefined;
+  team: ITeam;
 }
 
 function TeamProfile({ team }: Props) {
-  if (!team) return null;
-
   return (
     <>
       <h2>{team.name}</h2>

--- a/mellophone/frontend/src/sections/__tests__/SignUpForm.spec.tsx
+++ b/mellophone/frontend/src/sections/__tests__/SignUpForm.spec.tsx
@@ -37,30 +37,10 @@ it("Displays the error message of signUp if it throws an error", async () => {
   const signUp = jest.fn(async () => {
     throw new Error(message);
   });
-  const { getByLabelText, getByText, queryByText } = render(
-    <SignUpForm signUp={signUp} />
-  );
+  const { getByText, queryByText } = render(<SignUpForm signUp={signUp} />);
 
-  fireEvent.input(getByLabelText("Email"), {
-    target: { value: "username@email.com" },
-  });
-  fireEvent.input(getByLabelText("Password"), {
-    target: { value: "hunter2" },
-  });
-  fireEvent.input(getByLabelText("First name"), {
-    target: { value: "Nicholas" },
-  });
-  fireEvent.input(getByLabelText("Last name"), {
-    target: { value: "Whittaker" },
-  });
   fireEvent.click(getByText("Sign up"));
 
   await wait(() => expect(queryByText(message)).not.toBe(null));
   expect(signUp).toBeCalledTimes(1);
-  expect(signUp).toBeCalledWith(
-    "username@email.com",
-    "hunter2",
-    "Nicholas",
-    "Whittaker"
-  );
 });

--- a/mellophone/frontend/src/types.ts
+++ b/mellophone/frontend/src/types.ts
@@ -11,20 +11,10 @@ export interface ITeam {
   website: string;
 }
 
-export interface ITeamToBeCreated {
-  name: string;
-  website: string;
-}
-
 export interface IMeeting {
   id: number;
   name: string;
   venue?: string;
   dateHeld: Date;
   team: ITeam;
-}
-
-export interface IMeetingToBeCreated {
-  name: string;
-  venue?: string;
 }

--- a/mellophone/frontend/src/utils/TestRenderer.tsx
+++ b/mellophone/frontend/src/utils/TestRenderer.tsx
@@ -4,10 +4,13 @@ import SessionStore from "../stores/SessionStore";
 import TeamStore from "../stores/TeamStore";
 import { INetworkLayer, NetworkLayer, NetworkContext } from "../network";
 import { render, RenderResult } from "@testing-library/react";
+import { IUser } from "../types";
+import mock from "./mock";
 
 export default class TestRenderer {
   stores: ApplicationStores;
   network: INetworkLayer;
+  user?: IUser;
 
   constructor() {
     this.stores = {
@@ -27,18 +30,14 @@ export default class TestRenderer {
     return this;
   }
 
-  render(component: React.ReactNode): RenderResult {
-    const stores = {
-      ...this.stores,
-    };
-    const network = {
-      ...NetworkLayer,
-      ...this.network,
-    };
+  asAuthenticatedUser(user?: IUser) {
+    this.stores.sessionStore.signIn(user || mock.user());
+  }
 
+  render(component: React.ReactNode): RenderResult {
     return render(
-      <NetworkContext.Provider value={network}>
-        <StoresContext.Provider value={stores}>
+      <NetworkContext.Provider value={this.network}>
+        <StoresContext.Provider value={this.stores}>
           {component}
         </StoresContext.Provider>
       </NetworkContext.Provider>

--- a/mellophone/frontend/src/utils/TestRenderer.tsx
+++ b/mellophone/frontend/src/utils/TestRenderer.tsx
@@ -4,13 +4,10 @@ import SessionStore from "../stores/SessionStore";
 import TeamStore from "../stores/TeamStore";
 import { INetworkLayer, NetworkLayer, NetworkContext } from "../network";
 import { render, RenderResult } from "@testing-library/react";
-import { IUser } from "../types";
-import mock from "./mock";
 
 export default class TestRenderer {
   stores: ApplicationStores;
   network: INetworkLayer;
-  user?: IUser;
 
   constructor() {
     this.stores = {
@@ -28,10 +25,6 @@ export default class TestRenderer {
   withNetwork(network: Partial<INetworkLayer>): TestRenderer {
     Object.assign(this.network, network);
     return this;
-  }
-
-  asAuthenticatedUser(user?: IUser) {
-    this.stores.sessionStore.signIn(user || mock.user());
   }
 
   render(component: React.ReactNode): RenderResult {

--- a/mellophone/frontend/src/utils/mock.ts
+++ b/mellophone/frontend/src/utils/mock.ts
@@ -30,12 +30,12 @@ class Mock {
     };
   }
 
-  meeting(meeting: Partial<ITeam> = {}): IMeeting {
+  meeting(meeting: Partial<IMeeting> = {}): IMeeting {
     this.meetingCount++;
     return {
       id: this.meetingCount,
-      name: btoa(this.meetingCount.toString()),
-      venue: btoa(this.meetingCount.toString()),
+      name: "Meeting " + btoa(this.meetingCount.toString()),
+      venue: "Meeting venue " + btoa(this.meetingCount.toString()),
       dateHeld: new Date(),
       team: this.team(),
       ...meeting,

--- a/mellophone/frontend/src/utils/mock.ts
+++ b/mellophone/frontend/src/utils/mock.ts
@@ -1,4 +1,4 @@
-import { IUser, ITeam } from "../types";
+import { IUser, ITeam, IMeeting } from "../types";
 
 /**
  * Generates mock domain objects, attempting to populate fields with unique
@@ -7,6 +7,7 @@ import { IUser, ITeam } from "../types";
 class Mock {
   private userCount = 0;
   private teamCount = 0;
+  private meetingCount = 0;
 
   user(user: Partial<IUser> = {}): IUser {
     this.userCount++;
@@ -26,6 +27,18 @@ class Mock {
       name: `Team #${this.teamCount}`,
       website: btoa(this.teamCount.toString()),
       ...team,
+    };
+  }
+
+  meeting(meeting: Partial<ITeam> = {}): IMeeting {
+    this.meetingCount++;
+    return {
+      id: this.meetingCount,
+      name: btoa(this.meetingCount.toString()),
+      venue: btoa(this.meetingCount.toString()),
+      dateHeld: new Date(),
+      team: this.team(),
+      ...meeting,
     };
   }
 }

--- a/mellophone/frontend/src/utils/requireAuthentication.tsx
+++ b/mellophone/frontend/src/utils/requireAuthentication.tsx
@@ -39,24 +39,3 @@ function requireAuthentication<
 }
 
 export default requireAuthentication;
-
-/**
- * Provides a shortcut to silencing the warning given when no user is authenticated in requireAuthentication().
- *
- * Returns a method which can be called to cleanup after the applicable tests have been run.
- */
-export const silenceAuthWarnings = () => {
-  if (process.env.NODE_ENV !== "test") {
-    throw new Error("silenceAuthWarnings() is only for use in testing.");
-  }
-
-  const originalWarn = console.warn;
-  console.warn = (...args: any[]) => {
-    if (/No user in sessionStore, no content rendered./.test(args[0])) return;
-    originalWarn.call(console, ...args);
-  };
-
-  return () => {
-    console.warn = originalWarn;
-  };
-};

--- a/mellophone/frontend/src/utils/requireAuthentication.tsx
+++ b/mellophone/frontend/src/utils/requireAuthentication.tsx
@@ -1,4 +1,4 @@
-import React, { ElementType, useContext, useEffect } from "react";
+import React from "react";
 import { autorun } from "mobx";
 import { RouteComponentProps } from "@reach/router";
 import { observer } from "mobx-react-lite";
@@ -17,11 +17,11 @@ import { StoresContext } from "../stores";
  */
 function requireAuthentication<
   RouteProps extends RouteComponentProps = RouteComponentProps
->(Child: ElementType, Fallback?: ElementType) {
+>(Child: React.ElementType, Fallback?: React.ElementType) {
   return observer((props: RouteProps) => {
-    const { sessionStore } = useContext(StoresContext);
+    const { sessionStore } = React.useContext(StoresContext);
 
-    useEffect(() => {
+    React.useEffect(() => {
       // If a user is/becomes anonymous, redirect them to sign in
       return autorun(() => {
         if (!sessionStore.user.get() && !Fallback) {

--- a/mellophone/frontend/src/utils/requireAuthentication.tsx
+++ b/mellophone/frontend/src/utils/requireAuthentication.tsx
@@ -15,8 +15,10 @@ import { StoresContext } from "../stores";
  *
  * If a user is authenticated, the <Child/> will be rendered.
  */
-function requireAuthentication(Child: ElementType, Fallback?: ElementType) {
-  return observer((props: RouteComponentProps) => {
+function requireAuthentication<
+  RouteProps extends RouteComponentProps = RouteComponentProps
+>(Child: ElementType, Fallback?: ElementType) {
+  return observer((props: RouteProps) => {
     const { sessionStore } = useContext(StoresContext);
 
     useEffect(() => {
@@ -37,3 +39,24 @@ function requireAuthentication(Child: ElementType, Fallback?: ElementType) {
 }
 
 export default requireAuthentication;
+
+/**
+ * Provides a shortcut to silencing the warning given when no user is authenticated in requireAuthentication().
+ *
+ * Returns a method which can be called to cleanup after the applicable tests have been run.
+ */
+export const silenceAuthWarnings = () => {
+  if (process.env.NODE_ENV !== "test") {
+    throw new Error("silenceAuthWarnings() is only for use in testing.");
+  }
+
+  const originalWarn = console.warn;
+  console.warn = (...args: any[]) => {
+    if (/No user in sessionStore, no content rendered./.test(args[0])) return;
+    originalWarn.call(console, ...args);
+  };
+
+  return () => {
+    console.warn = originalWarn;
+  };
+};


### PR DESCRIPTION
This adds a few more tests for entire pages of the application. It can be a tad verbose since it these pages (sometime) require authentication, but it gives some confidence that these kinds of rules are being enforced.

A similar thing applies for mocking backend requests, but I think that injection via context is simple to understand and apply.

This also cleans up some `FooToBeCreated` types that some async methods use, I'm happy listing each field explicitly for now. In future, Typescript's `Partial<>` should be fine, rather than creating a whole new type each time.