### PR TITLE
Automating server updates

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -88,4 +88,4 @@ cache:
     - echo "$PRODUCTION_PRIVATE_SSH_KEY" | tr -d '\r' | ssh-add - > /dev/null
     - pipenv sync --keep-outdated
     - pipenv run python mellophone/manage.py collectstatic --clear --no-input --no-post-process
-    - rsync -a -e ssh --delete-excluded --exclude-from=.rsyncignore config mellophone Pipfile Pipfile.lock conductor@157.230.241.239:~/production
+    - rsync -a -e ssh --delete-excluded --exclude-from=.rsyncignore config mellophone Pipfile Pipfile.lock conductor@157.230.241.239:~/latest-deployment

--- a/Pipfile
+++ b/Pipfile
@@ -18,7 +18,7 @@ gunicorn = "~=19.0"
 python_version = "3.6"
 
 [scripts]
-migrate  = "python mellophone/manage.py migrate"
+migrate     = "python mellophone/manage.py migrate"
 server      = "python mellophone/manage.py runserver 0.0.0.0:8000"
 lint        = "pylint mellophone/backend"
 test-unit   = "python mellophone/manage.py test backend"

--- a/config/update-mellophone.service
+++ b/config/update-mellophone.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Restarts Mellophone, performing any necessary work (dependency updates, database migrations)
+
+[Service]
+User=conductor
+WorkingDirectory=/home/conductor
+ExecStartPre=+/bin/systemctl stop nginx gunicorn
+ExecStart=/bin/sh update-mellophone.sh
+ExecStartPost=+/bin/systemctl start nginx gunicorn
+
+[Install]
+WantedBy=multi-user.target

--- a/config/update-mellophone.service
+++ b/config/update-mellophone.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Restarts Mellophone, performing any necessary work (dependency updates, database migrations)
+ConditionPathExists=/home/conductor/latest-deployment
 
 [Service]
 User=conductor

--- a/config/update-mellophone.timer
+++ b/config/update-mellophone.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=Triggers mellophone-restart.service every day
+
+[Timer]
+OnCalendar=daily
+
+[Install]
+WantedBy=timers.target

--- a/scripts/set-up-mellophone.sh
+++ b/scripts/set-up-mellophone.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+
+# This is a collection of most of the commands I ran to set up Mellophone on a
+# $5/month Ubnutu DO droplet. Useful if I'm trying to remember a command I ran.
+
+# https://www.digitalocean.com/community/tutorials/initial-server-setup-with-ubuntu-18-04
+ssh-keyscan 157.230.241.239 ~/.ssh/known_hosts
+ssh -i .ssh/mellophone root@157.230.241.239
+adduser conductor # provide password, default answers
+usermod -aG sudo conductor
+ufw allow OpenSSH
+ufw enable
+rsync --archive --chown=conductor:conductor ~/.ssh /home/conductor
+
+# https://www.digitalocean.com/community/tutorials/how-to-set-up-django-with-postgres-nginx-and-gunicorn-on-ubuntu-18-04
+ssh -i .ssh/mellophone conductor@157.230.241.239
+sudo apt update
+sudo apt install python3-pip python3-dev libpq-dev postgresql postgresql-contrib nginx
+pip3 install --user pipenv
+# restart shell
+sudo -u postgres postgres
+CREATE DATABASE mellophone
+\password postgres
+# sync files (including env) into ~/production
+nano production/.env
+sudo cp production/config/gunicorn.socket /etc/systemd/system
+sudo cp production/config/gunicorn.service /etc/systemd/system
+sudo systemctl start gunicorn.socket
+sudo systemctl enable gunicorn.socket
+sudo systemctl daemon-reload
+sudo systemctl restart gunicorn
+sudo cp production/config/nginx-mellophone /etc/nginx/sites-available/mellophone
+sudo nginx -t
+sudo systemctl restart nginx
+
+# https://certbot.eff.org/lets-encrypt/ubuntubionic-nginx
+# https://www.digitalocean.com/community/tutorials/how-to-install-an-ssl-certificate-from-a-commercial-certificate-authority
+# https://certbot-dns-digitalocean.readthedocs.io/en/stable/
+sudo apt update
+sudo apt install software-properties-common
+sudo add-apt-repository universe
+sudo add-apt-repository ppa:certbot/certbot
+sudo apt update
+sudo apt install certbot python3-certbot-dns-digitalocean
+sudo vi /root/digitalocean.ini # declare API key per certbot-dns-digitalocean
+sudo chmod 600 /root/ssl/digitalocean.ini
+sudo certbot certonly \
+  -i nginx \
+  --dns-digitalocean --dns-digitalocean-credentials=/root/ssl/digitalocean.ini
+  -d "*.mellophone.pink" -d "mellophone.pink" \
+  --server https://acme-v02.api.letsencrypt.org/directory

--- a/scripts/update-mellophone.sh
+++ b/scripts/update-mellophone.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 rsync -a --exclude .env --delete latest-deployment/ production/
+rm -rf latest-deployment
 cd production
 ~/.local/bin/pipenv sync --keep-outdated
 ~/.local/bin/pipenv run migrate

--- a/scripts/update-mellophone.sh
+++ b/scripts/update-mellophone.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+rsync -a --exclude .env --delete latest-deployment/ production/
+cd production
+~/.local/bin/pipenv sync --keep-outdated
+~/.local/bin/pipenv run migrate


### PR DESCRIPTION
Resolves #8 

This changes CI to push to the `/latest-deployment` directory, instead of `/production`. If the former exists, `update-mellophone.service` will pick it up, running through any typical updates.

I've also added `scripts/set-up-mellophone.sh`, which contains most of the commands I needed to set up Mellophone on DO.