### PR TITLE
Fix failing build caused by caching/Dockerfile problems

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -86,7 +86,7 @@ cache:
       - e2e
   script:
     - pipenv clean
-    - pipenv sync --keep-outdated
+    - pipenv sync --dev --keep-outdated
     - pipenv run migrate
     - sh scripts/get-frontend-build.sh
     - sh scripts/test-e2e.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -85,10 +85,10 @@ cache:
     paths:
       - e2e
   script:
-    - sh scripts/get-frontend-build.sh
     - pipenv clean
     - pipenv sync --keep-outdated
     - pipenv run migrate
+    - sh scripts/get-frontend-build.sh
     - sh scripts/test-e2e.sh
 
 "Deploy":

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
 FROM ubuntu:18.04
 
-RUN apt-get -qqy update && DEBIAN_FRONTEND=noninteractive apt-get -qqy --no-install-recommends install \
+RUN apt-get -qqy update && DEBIAN_FRONTEND=noninteractive apt-get -qqy install \
     curl \
     firefox \
     libpq-dev \
+    nginx \
     openssh-client \
     postgresql \
+    postgresql-contrib \
+    python3-dev \
     python3-pip \
     rsync \
     unzip


### PR DESCRIPTION
Long story short, I tried clearing the cache and re-running the `master` pipeline. It failed because some dependencies were being persisted from cache (namely `psycopg2`, which is compiled each time it is installed). Reinstalling and building these dependencies caused further errors because required packages were missing.