### PR TITLE
Fix "Create new team" form and rewrite teams duck

### DIFF
--- a/mellophone/frontend/src/ducks/__tests__/teams.spec.ts
+++ b/mellophone/frontend/src/ducks/__tests__/teams.spec.ts
@@ -1,99 +1,31 @@
 import { createStore } from "redux";
-import reducer, {
-  setTeamsPending,
-  setTeamsFulfilled,
-  setTeamsRejected,
-  loadTeamsThunk,
-} from "../teams";
+import reducer, { appendTeams } from "../teams";
 import mock from "../../utils/mock";
 import { clearSession } from "../session";
 
-it("Is in a pending state by default", () => {
+it("Has no teams loaded by default", () => {
   const store = createStore(reducer);
 
-  expect(store.getState().status).toBe("pending");
-});
-
-it("Sets the reducer to a pending state when it was previously errored", () => {
-  const store = createStore(reducer, {
-    status: "rejected",
-    teams: [],
-    error: new Error(),
-  });
-
-  store.dispatch(setTeamsPending());
-
-  expect(store.getState().status).toBe("pending");
-  expect(store.getState().error).toBe(undefined);
-});
-
-it("Sets the reducer to a pending state when it was previously fulfilled", () => {
-  const store = createStore(reducer, {
-    status: "fulfilled",
-    teams: [mock.team()],
-    error: undefined,
-  });
-
-  store.dispatch(setTeamsPending());
-
-  expect(store.getState().status).toBe("pending");
   expect(store.getState().teams).toHaveLength(0);
-});
-
-it("Sets the reducer to fulfilled", () => {
-  const store = createStore(reducer);
-  const teams = [mock.team()];
-
-  store.dispatch(setTeamsFulfilled(teams));
-
-  expect(store.getState().status).toBe("fulfilled");
-  expect(store.getState().teams).toEqual(teams);
-});
-
-it("Sets the reducer to rejected", () => {
-  const store = createStore(reducer);
-
-  store.dispatch(setTeamsRejected(new Error("Something went wrong")));
-
-  expect(store.getState().status).toBe("rejected");
-  expect(store.getState().error!.message).toBe("Something went wrong");
 });
 
 it("Reacts to the session being cleared", () => {
   const store = createStore(reducer, {
-    status: "fulfilled",
     teams: [mock.team()],
-    error: undefined,
   });
 
   store.dispatch(clearSession());
 
-  expect(store.getState().status).toBe("pending");
   expect(store.getState().teams).toHaveLength(0);
 });
 
-it("loadTeamsThunk() - Dispatches a pending and fulfilled action on green path", async () => {
-  const dispatch = jest.fn();
-  const teams = [mock.team()];
-  const expectedPendingAction = setTeamsPending();
-  const expectedFulfilledAction = setTeamsFulfilled(teams);
+it("Does not append duplicate teams", () => {
+  const team = mock.team();
+  const store = createStore(reducer, {
+    teams: [team],
+  });
 
-  await loadTeamsThunk(Promise.resolve(teams))(dispatch);
+  store.dispatch(appendTeams([team]));
 
-  expect(dispatch).toBeCalledTimes(2);
-  expect(dispatch.mock.calls[0]).toEqual([expectedPendingAction]);
-  expect(dispatch.mock.calls[1]).toEqual([expectedFulfilledAction]);
-});
-
-it("loadTeamsThunk() - Dispatches a pending and rejected action on red path", async () => {
-  const dispatch = jest.fn();
-  const error = new Error("Something went wrong");
-  const expectedPendingAction = setTeamsPending();
-  const expectedRejectedAction = setTeamsRejected(error);
-
-  await loadTeamsThunk(Promise.reject(error))(dispatch);
-
-  expect(dispatch).toBeCalledTimes(2);
-  expect(dispatch.mock.calls[0]).toEqual([expectedPendingAction]);
-  expect(dispatch.mock.calls[1]).toEqual([expectedRejectedAction]);
+  expect(store.getState().teams).toHaveLength(1);
 });

--- a/mellophone/frontend/src/ducks/__tests__/teams.spec.ts
+++ b/mellophone/frontend/src/ducks/__tests__/teams.spec.ts
@@ -19,6 +19,16 @@ it("Reacts to the session being cleared", () => {
   expect(store.getState().teams).toHaveLength(0);
 });
 
+it("Allows teams to appended", () => {
+  const team = mock.team();
+  const store = createStore(reducer);
+
+  store.dispatch(appendTeams([team]));
+
+  expect(store.getState().teams).toHaveLength(1);
+  expect(store.getState().teams[0]).toEqual(team);
+});
+
 it("Does not append duplicate teams", () => {
   const team = mock.team();
   const store = createStore(reducer, {

--- a/mellophone/frontend/src/pages/CreateTeam.tsx
+++ b/mellophone/frontend/src/pages/CreateTeam.tsx
@@ -7,13 +7,11 @@ import CreateTeamForm from "../components/CreateTeamForm";
 import { navigate } from "../utils/routing";
 import requireAuthentication from "../utils/requireAuthentication";
 import { useNetwork } from "../network";
-import { AppState } from "../ducks";
-import { appendTeam } from "../ducks/teams";
+import { appendTeams } from "../ducks/teams";
 import { ITeam } from "../types";
 
 interface Props extends RouteComponentProps {
-  teamsLoaded: boolean;
-  appendTeam(team: ITeam): void;
+  appendTeams(teams: ITeam[]): void;
 }
 
 function CreateTeam(props: Props) {
@@ -21,27 +19,23 @@ function CreateTeam(props: Props) {
 
   const createTeam = async (name: string, website: string) => {
     const team = await postTeam(name, website);
-    props.appendTeam(team);
+    props.appendTeams([team]);
     navigate(`/teams/${team.id}`);
   };
 
   return (
     <Main>
       <h1>Create a new team</h1>
-      {props.teamsLoaded && <CreateTeamForm createTeam={createTeam} />}
+      <CreateTeamForm createTeam={createTeam} />
     </Main>
   );
 }
 
-const mapStateToProps = (state: AppState) => ({
-  teamsLoaded: state.teams.status === "fulfilled",
-});
-
 const mapDispatchToProps = {
-  appendTeam,
+  appendTeams,
 };
 
 export default connect(
-  mapStateToProps,
+  null,
   mapDispatchToProps
 )(requireAuthentication<Props>(CreateTeam));

--- a/mellophone/frontend/src/pages/__tests__/Home.spec.tsx
+++ b/mellophone/frontend/src/pages/__tests__/Home.spec.tsx
@@ -27,8 +27,10 @@ it("Renders a feed when a user is logged in", async () => {
 
 it("Shows the feed immediately if some/all teams are loaded", () => {
   const teams = [mock.team(), mock.team()];
+  const getTeamsOfSessionUser = jest.fn(async () => []);
   const { queryByText } = new TestRenderer()
-    .withStores({ teams: { teams, status: "fulfilled", error: undefined } })
+    .withStores({ teams: { teams } })
+    .withNetwork({ getTeamsOfSessionUser })
     .asAuthenticatedUser()
     .render(<Home />);
 
@@ -36,11 +38,25 @@ it("Shows the feed immediately if some/all teams are loaded", () => {
   expect(queryByText(teams[1].name)).not.toBe(null);
 });
 
+it("Shows an error if loading a user's teams fails", async () => {
+  const message = "Your teams could not be loaded at this time";
+  const getTeamsOfSessionUser = jest.fn(async () => {
+    throw new Error(message);
+  });
+  const { queryByText } = new TestRenderer()
+    .asAuthenticatedUser()
+    .withNetwork({ getTeamsOfSessionUser })
+    .render(<Home />);
+
+  await wait(() => expect(queryByText(message)).not.toBe(null));
+  expect(getTeamsOfSessionUser).toBeCalledTimes(1);
+});
+
 it("Prompts a user to create a team if they are not a member of any teams", () => {
   const getTeamsOfSessionUser = jest.fn(async () => []);
   const { queryByText } = new TestRenderer()
     .asAuthenticatedUser()
-    .withStores({ teams: { teams: [], status: "fulfilled", error: undefined } })
+    .withStores({ teams: { teams: [] } })
     .withNetwork({ getTeamsOfSessionUser })
     .render(<Home />);
 


### PR DESCRIPTION
Closes #32

So I went the longer route in fixing this to make the `teams` duck append only, which makes it's behaviour much easier to understand.

The home page will now handle the request to load a user's teams itself, rather than passing it off to the now removed `loadTeamsThunk()` handler.

This would be a good thing to have an E2E test for, if I can find the time to set them up properly.