### PR TITLE
Refactor the backend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     image: "registry.gitlab.com/nchlswhttkr/mellophone:master"
     working_dir: "/home/conductor/dev"
     environment:
+      # Ensures all 'dev' containers use the same dependencies
       - "WORKON_HOME=/home/conductor/dev/docker/dev/.venv"
     volumes:
       - ".:/home/conductor/dev"

--- a/mellophone/backend/controllers/meeting.py
+++ b/mellophone/backend/controllers/meeting.py
@@ -6,7 +6,9 @@ from backend.serializers import serialize_meeting, serialize_item
 from backend.services.identity import IdentityService
 from backend.services.team import TeamService
 from backend.services.meeting import MeetingService
-from backend.services.item import ItemService, InvalidItemException
+from backend.services.permissions import PermissionsService
+from backend.services.item import ItemService
+from backend.exceptions import ForbiddenException
 
 
 class MeetingController:
@@ -23,15 +25,12 @@ class MeetingController:
         fine to get the team ID from the meeting itself for now, as retreiving
         meetings is not a particularly expensive operation.
         """
-        user = IdentityService.get_session_user(request)
-        if user is None:
-            return GenericViews.authentication_required_response(request)
-
+        user = IdentityService.get_required_session_user(request)
         meeting_id = int(re.match(r"/api/meetings/([0-9]*)", request.path)[1])
-        meeting = MeetingService.get_meeting_with_id(meeting_id)
 
-        if not TeamService.is_user_in_team_with_id(user, meeting.team.id):
-            return GenericViews.forbidden_response(request)
+        meeting = MeetingService.get(meeting_id)
+        if not PermissionsService.can_read_meetings_of_team(user.id, meeting.team.id):
+            raise ForbiddenException("You are not allowed to view this meeting")
 
         return JsonResponse({"meeting": serialize_meeting(meeting)}, status=200)
 
@@ -39,14 +38,11 @@ class MeetingController:
         """
         Gets the meetings of a given team.
         """
-        user = IdentityService.get_session_user(request)
-        if user is None:
-            return GenericViews.authentication_required_response(request)
-
+        user = IdentityService.get_required_session_user(request)
         team_id = re.match(r"/api/teams/([0-9]*)/meetings", request.path)[1]
 
-        if not TeamService.is_user_in_team_with_id(user, team_id):
-            return GenericViews.forbidden_response(request)
+        if not PermissionsService.can_read_meetings_of_team(user.id, team_id):
+            raise ForbiddenException("You are not allowed to view this team's meetings")
 
         meetings = MeetingService.get_meetings_of_team_with_id(team_id)
         return JsonResponse(
@@ -58,39 +54,34 @@ class MeetingController:
         """
         Creates a meeting for the given team.
         """
-        user = IdentityService.get_session_user(request)
-        if user is None:
-            return GenericViews.authentication_required_response(request)
-
+        user = IdentityService.get_required_session_user(request)
         team_id = re.match(r"/api/teams/([0-9]*)/meetings", request.path)[1]
-
-        if not TeamService.is_user_in_team_with_id(user, team_id):
-            return GenericViews.forbidden_response(request)
-
         body = json.loads(request.body.decode("utf-8"))
         name = body["name"]
         venue = body["venue"] if "venue" in body else ""
 
-        meeting = MeetingService.create_meeting_for_team_with_id(team_id, name, venue)
+        if not PermissionsService.can_write_meetings_of_team(user.id, team_id):
+            raise ForbiddenException(
+                "You are not allowed to create a meeting for this team"
+            )
 
+        meeting = MeetingService.create(team_id, name, venue)
         return JsonResponse({"meeting": serialize_meeting(meeting)}, status=201)
 
     def get_items_of_meeting(self, request):
         """
         Obtains the items of a meeting
         """
-        user = IdentityService.get_session_user(request)
-        if user is None:
-            return GenericViews.authentication_required_response(request)
-
+        user = IdentityService.get_required_session_user(request)
         meeting_id = int(re.match(r"/api/meetings/([0-9]*)/items", request.path)[1])
-        meeting = MeetingService.get_meeting_with_id(meeting_id)
 
-        if not TeamService.is_user_in_team_with_id(user, meeting.team.id):
-            return GenericViews.forbidden_response(request)
+        meeting = MeetingService.get(meeting_id)
+        if not PermissionsService.can_write_meetings_of_team(user.id, meeting.team.id):
+            raise ForbiddenException(
+                "You are not allowed to view the items of this meeting"
+            )
 
         items = ItemService.get_items_of_meeting_with_id(meeting_id)
-
         return JsonResponse(
             {"items": [serialize_item(item) for item in items]}, status=200
         )
@@ -99,23 +90,17 @@ class MeetingController:
         """
         Creates an item within a meeting.
         """
-        user = IdentityService.get_session_user(request)
-        if user is None:
-            return GenericViews.authentication_required_response(request)
-
+        user = IdentityService.get_required_session_user(request)
         meeting_id = int(re.match(r"/api/meetings/([0-9]*)/items", request.path)[1])
-        meeting = MeetingService.get_meeting_with_id(meeting_id)
-
-        if not TeamService.is_user_in_team_with_id(user, meeting.team.id):
-            return GenericViews.forbidden_response(request)
-
         body = json.loads(request.body.decode("utf-8"))
         name = body["name"]
         description = body["description"]
 
-        try:
-            item = ItemService.create_item_for_meeting(meeting, name, description)
-        except InvalidItemException as error:
-            return GenericViews.invalid_request_response(request, error)
+        meeting = MeetingService.get(meeting_id)
+        if not PermissionsService.can_write_meetings_of_team(user.id, meeting.team.id):
+            raise ForbiddenException(
+                "You are not allowed to create items for this meeting"
+            )
 
+        item = ItemService.create(meeting.id, name, description)
         return JsonResponse({"item": serialize_item(item)}, status=201)

--- a/mellophone/backend/controllers/team.py
+++ b/mellophone/backend/controllers/team.py
@@ -16,11 +16,9 @@ class TeamController:
         """
         Get the teams of which the session user is a member.
         """
-        user = IdentityService.get_session_user(request)
-        if user is None:
-            return GenericViews.authentication_required_response(request)
+        user = IdentityService.get_required_session_user(request)
 
-        teams = TeamService.get_teams_of_user(user)
+        teams = TeamService.get_teams_of_user_with_id(user.id)
         return JsonResponse(
             {"teams": [serialize_team(team) for team in teams]}, status=200
         )
@@ -32,25 +30,20 @@ class TeamController:
         If roles are implemented, this may also include asssigning them as an
         'owner'-like role.
         """
-        owner = IdentityService.get_session_user(request)
-        if owner is None:
-            return GenericViews.authentication_required_response(request)
-
+        user = IdentityService.get_required_session_user(request)
         body = json.loads(request.body.decode("utf-8"))
         name = body["name"]
         website = body["website"]
 
-        team = TeamService.create_team_with_user_as_owner(owner, name, website)
+        team = TeamService.create_team_with_user_as_owner(user, name, website)
         return JsonResponse({"team": serialize_team(team)}, status=201)
 
     def get_team_by_id(self, request):
         """
         Get a team by their ID.
         """
-        user = IdentityService.get_session_user(request)
-        if user is None:
-            return GenericViews.authentication_required_response(request)
-
+        user = IdentityService.get_required_session_user(request)
         team_id = re.match(r"/api/teams/([0-9]*)", request.path)[1]
-        team = TeamService.get_team_with_id(team_id)
+
+        team = TeamService.get(team_id)
         return JsonResponse({"team": serialize_team(team)}, status=200)

--- a/mellophone/backend/exceptions.py
+++ b/mellophone/backend/exceptions.py
@@ -1,0 +1,10 @@
+class BadRequestException(Exception):
+    pass
+
+
+class ForbiddenException(Exception):
+    pass
+
+
+class AuthenticationRequiredException(Exception):
+    pass

--- a/mellophone/backend/models.py
+++ b/mellophone/backend/models.py
@@ -25,8 +25,7 @@ class Team(models.Model):
 
 class Membership(models.Model):
     """
-    Individual users have membership with a team through these instances. Roles
-    are not yet handled, but they will likely also sit within this model.
+    Individual users have membership with a team through these instances.
     """
 
     user = models.ForeignKey(User, on_delete=models.CASCADE)

--- a/mellophone/backend/services/identity.py
+++ b/mellophone/backend/services/identity.py
@@ -1,4 +1,6 @@
 from django.contrib.auth import authenticate, login, logout
+from backend.services.user import UserService
+from backend.exceptions import AuthenticationRequiredException, BadRequestException
 
 
 class IdentityService:
@@ -8,13 +10,26 @@ class IdentityService:
     """
 
     @staticmethod
+    def sign_up(request, email, password, first_name, last_name):
+        """
+        Creates an account and signs the user in.
+        """
+
+        UserService.create(email, password, first_name, last_name)
+        return IdentityService.sign_in(request, email, password)
+
+    @staticmethod
     def sign_in(request, email, password):
         """
-        Attempt to log a user in given their credentials.
+        Attempt to log a user in given their credentials, throwing if
+        authentication fails.
         """
         user = authenticate(request, username=email, password=password)
-        if user is not None:
-            login(request, user)
+        if user is None:
+            raise BadRequestException("Sign in failed")
+
+        login(request, user)
+        return user
 
     @staticmethod
     def sign_out(request):
@@ -32,3 +47,19 @@ class IdentityService:
         if request.user.is_authenticated:
             return request.user
         return None
+
+    @staticmethod
+    def get_required_session_user(request):
+        """
+        Will return a user's identity if they are authenticated, but will throw
+        if no user is authenticated.
+
+        This can be used to as the first step in handling a request, stopping
+        users who are not authenticating from proceeding.
+        """
+        user = IdentityService.get_session_user(request)
+        if user is None:
+            raise AuthenticationRequiredException(
+                "You are not logged in, authentication is required."
+            )
+        return user

--- a/mellophone/backend/services/item.py
+++ b/mellophone/backend/services/item.py
@@ -1,10 +1,23 @@
 from backend.models import Item
+from backend.exceptions import BadRequestException
 
 
 class ItemService:
-    """
-    Handles logic around the creation, retrieval and updating of meeting items.
-    """
+    @staticmethod
+    def get(id):
+        return Item.objects.get(pk=id)
+
+    @staticmethod
+    def create(meeting_id, name, description):
+        if name == "":
+            raise BadRequestException("Meeting items must have a name")
+        if description == "":
+            raise BadRequestException("Meeting items must have a description")
+
+        item = Item.objects.create(
+            name=name, description=description, meeting_id=meeting_id
+        )
+        return item
 
     @staticmethod
     def get_items_of_meeting_with_id(meeting_id):
@@ -12,20 +25,3 @@ class ItemService:
         Retrieves items associated with a given meeting.
         """
         return Item.objects.filter(meeting__id=meeting_id).order_by("date_created")
-
-    @staticmethod
-    def create_item_for_meeting(meeting, name, description):
-        """
-        Creates an item for a meeting.
-        """
-        if name == "":
-            raise InvalidItemException("Meeting items must have a name.")
-        if description == "":
-            raise InvalidItemException("Meeting items must have a description")
-
-        item = Item.objects.create(name=name, description=description, meeting=meeting)
-        return item
-
-
-class InvalidItemException(Exception):
-    pass

--- a/mellophone/backend/services/meeting.py
+++ b/mellophone/backend/services/meeting.py
@@ -1,20 +1,19 @@
 from backend.models import Meeting
+from backend.exceptions import BadRequestException
 
 
 class MeetingService:
-    """
-    Handles logic around the creation, retrieval and updating of meetings.
-    """
-
     @staticmethod
-    def create_meeting_for_team_with_id(team_id, name, venue=""):
+    def create(team_id, name, venue=""):
         """
         Creates a meeting for the given team.
         """
+        if name == "":
+            raise BadRequestException("Meetings must have a name")
         return Meeting.objects.create(team_id=team_id, name=name, venue=venue)
 
     @staticmethod
-    def get_meeting_with_id(meeting_id):
+    def get(meeting_id):
         """
         Retrieves a meeting by its ID.
         """

--- a/mellophone/backend/services/membership.py
+++ b/mellophone/backend/services/membership.py
@@ -1,0 +1,19 @@
+from backend.models import Membership
+
+
+class MembershipService:
+    @staticmethod
+    def create(user_id, team_id):
+        return Membership.objects.create(user_id=user_id, team_id=team_id)
+
+    @staticmethod
+    def get(membership_id):
+        return Membership.objects.filter(pk=id)
+
+    @staticmethod
+    def delete(membership):
+        membership.delete()
+
+    @staticmethod
+    def is_user_member_of_team(user_id, team_id):
+        return Membership.objects.filter(user__id=user_id, team__id=team_id).exists()

--- a/mellophone/backend/services/permissions.py
+++ b/mellophone/backend/services/permissions.py
@@ -1,0 +1,20 @@
+from backend.services.membership import MembershipService
+from backend.services.meeting import MeetingService
+
+
+class PermissionsService:
+    """
+    Abstracts logic around permission checking. Each method should be about
+    CRUDing a certain resource (eg READing a Meeting).
+
+    The intent is to group and abstract logic around permission checking so
+    that it can be changed from a single place in future.
+    """
+
+    @staticmethod
+    def can_write_meetings_of_team(user_id, team_id):
+        return MembershipService.is_user_member_of_team(user_id, team_id)
+
+    @staticmethod
+    def can_read_meetings_of_team(user_id, team_id):
+        return MembershipService.is_user_member_of_team(user_id, team_id)

--- a/mellophone/backend/services/tests/test_identity_service.py
+++ b/mellophone/backend/services/tests/test_identity_service.py
@@ -1,0 +1,48 @@
+from django.test import TestCase, RequestFactory
+from django.contrib.sessions.middleware import SessionMiddleware
+from django.contrib.auth.middleware import AuthenticationMiddleware
+from backend.services.identity import IdentityService
+from backend.exceptions import AuthenticationRequiredException
+
+
+class IdentityServiceTestCase(TestCase):
+    def setUp(self):
+        self.request_factory = RequestFactory()
+
+    def test_newly_authenticated_user_is_authenticated(self):
+        """
+        This exists to catch an edge case where a user would be created but
+        could not be authenticated against.
+
+        Using User.objects.create(...) instead of User.objects.create_user(...)
+        will not throw an error, but the created user can't be authenticated
+        against.
+
+        Who knows what Django does internally that's different from manually
+        adding a user? Just don't delete this test.
+        """
+        email = "john@email.com"
+
+        # Django does not include middleware in tests, so add it manually
+        # The request can be nondescript because it's just to satisfy Django
+        request = self.request_factory.get("/")
+        SessionMiddleware().process_request(request)
+        AuthenticationMiddleware().process_request(request)
+
+        user = IdentityService.sign_up(request, email, "hunter2", "John", "Doe")
+
+        self.assertTrue(user is not None)
+        self.assertEqual(user.email, email)
+
+    def test_can_stop_users_from_proceeding_if_not_logged_in(self):
+        """
+        Several routes depend on a method to get the session user that will
+        throw if no request user is logged in.
+        """
+        request = self.request_factory.get("/")
+        SessionMiddleware().process_request(request)
+        AuthenticationMiddleware().process_request(request)
+
+        with self.assertRaises(AuthenticationRequiredException):
+            IdentityService.get_required_session_user(request)
+

--- a/mellophone/backend/services/tests/test_item_service.py
+++ b/mellophone/backend/services/tests/test_item_service.py
@@ -1,58 +1,54 @@
 from time import sleep
 from django.test import TestCase
-from backend.services.item import ItemService, InvalidItemException
+from backend.services.item import ItemService
 from backend.services.team import TeamService
 from backend.services.meeting import MeetingService
 from backend.services.user import UserService
+from backend.exceptions import BadRequestException
 
 
 class ItemServiceTestCase(TestCase):
+    def setUp(self):
+        self.user = UserService.create("john@email.com", "hunter2", "John", "Doe")
+        self.team = TeamService.create_team_with_user_as_owner(
+            self.user, "John's team", ""
+        )
+        self.meeting = MeetingService.create(self.team.id, "A meeting")
+
     def test_get_items_of_meeting(self):
         """
         All the items of a meeting can be created and retreived
         """
-        user = UserService.create_user("john@email.com", "hunter2", "John", "Doe")
-        team = TeamService.create_team_with_user_as_owner(user, "Me and the boys", "")
-        meeting = MeetingService.create_meeting_for_team_with_id(team.id, "A meeting")
-
         item_name = "An item name"
         item_description = "A description for the item"
-        ItemService.create_item_for_meeting(meeting, item_name, item_description)
 
-        retrieved_item = ItemService.get_items_of_meeting_with_id(meeting.id)[0]
+        ItemService.create(self.meeting.id, item_name, item_description)
+        retrieved_item = ItemService.get_items_of_meeting_with_id(self.meeting.id)[0]
 
-        self.assertEqual(meeting.id, retrieved_item.meeting.id)
+        self.assertEqual(self.meeting.id, retrieved_item.meeting.id)
         self.assertEqual(item_name, retrieved_item.name)
         self.assertEqual(item_description, retrieved_item.description)
 
     def test_throws_if_no_name(self):
-        user = UserService.create_user("john@email.com", "hunter2", "John", "Doe")
-        team = TeamService.create_team_with_user_as_owner(user, "Me and the boys", "")
-        meeting = MeetingService.create_meeting_for_team_with_id(team.id, "A meeting")
-
-        with self.assertRaises(InvalidItemException):
-            ItemService.create_item_for_meeting(meeting, "", "A description")
+        with self.assertRaises(
+            BadRequestException, msg="Meeting items must have a name"
+        ):
+            ItemService.create(self.meeting.id, "", "Description")
 
     def test_throws_if_no_description(self):
-        user = UserService.create_user("john@email.com", "hunter2", "John", "Doe")
-        team = TeamService.create_team_with_user_as_owner(user, "Me and the boys", "")
-        meeting = MeetingService.create_meeting_for_team_with_id(team.id, "A meeting")
-
-        with self.assertRaises(InvalidItemException):
-            ItemService.create_item_for_meeting(meeting, "A name", "")
+        with self.assertRaises(
+            BadRequestException, msg="Meeting items must have a description"
+        ):
+            ItemService.create(self.meeting.id, "Name", "")
 
     def test_ordered_by_creation_date(self):
         """
         Items of a meeting are ordered by the date on which they are created.
         """
-        user = UserService.create_user("john@email.com", "hunter2", "John", "Doe")
-        team = TeamService.create_team_with_user_as_owner(user, "Me and the boys", "")
-        meeting = MeetingService.create_meeting_for_team_with_id(team.id, "A meeting")
-
-        first_item = ItemService.create_item_for_meeting(meeting, "First item", "-")
-        sleep(1)  # not necessary, but just for clarity's sake
-        second_item = ItemService.create_item_for_meeting(meeting, "Second item", "-")
-        meeting_items = ItemService.get_items_of_meeting_with_id(meeting.id)
+        first_item = ItemService.create(self.meeting.id, "First item", "-")
+        sleep(1)  # just so the second item is explicity older
+        second_item = ItemService.create(self.meeting.id, "Second item", "-")
+        meeting_items = ItemService.get_items_of_meeting_with_id(self.meeting.id)
 
         self.assertTrue(first_item.date_created < second_item.date_created)
         self.assertEqual(len(meeting_items), 2)

--- a/mellophone/backend/services/tests/test_meeting_service.py
+++ b/mellophone/backend/services/tests/test_meeting_service.py
@@ -2,20 +2,23 @@ from django.test import TestCase
 from backend.services.team import TeamService
 from backend.services.meeting import MeetingService
 from backend.services.user import UserService
+from backend.exceptions import BadRequestException
 
 
 class ItemServiceTestCase(TestCase):
-    def test_create_meeting(self):
+    def setUp(self):
+        self.user = UserService.create("john@email.com", "hunter2", "John", "Doe")
+        self.team = TeamService.create_team_with_user_as_owner(self.user, "John's Team", "")
+
+    def test_create(self):
         """
         A meeting can be created
         """
-        user = UserService.create_user("john@email.com", "hunter2", "John", "Doe")
-        team = TeamService.create_team_with_user_as_owner(user, "A team", "")
 
         meeting_name = "A meeting"
         meeting_venue = "A meeting venue"
-        meeting = MeetingService.create_meeting_for_team_with_id(
-            team.id, meeting_name, meeting_venue
+        meeting = MeetingService.create(
+            self.team.id, meeting_name, meeting_venue
         )
 
         self.assertEqual(meeting.name, meeting_name)
@@ -26,26 +29,27 @@ class ItemServiceTestCase(TestCase):
         A meeting can be created without a venue being provided, defaulting to
         an empty string
         """
-        user = UserService.create_user("john@email.com", "hunter2", "John", "Doe")
-        team = TeamService.create_team_with_user_as_owner(user, "A team", "")
-
         meeting_name = "A meeting"
-        meeting = MeetingService.create_meeting_for_team_with_id(team.id, meeting_name)
+        meeting = MeetingService.create(self.team.id, meeting_name)
 
         self.assertEqual(meeting.name, meeting_name)
         self.assertEqual(meeting.venue, "")
+
+    def test_create_meeting_throws_if_empty_name(self):
+        """
+        A meeting must have a name, an empty string is not accepted.
+        """
+        with self.assertRaises(BadRequestException, msg="A meeting must have a name"):
+            MeetingService.create(self.team.id, "", "-")
 
     def test_retrieve_meeting(self):
         """
         A meeting can be retrieved
         """
-        user = UserService.create_user("john@email.com", "hunter2", "John", "Doe")
-        team = TeamService.create_team_with_user_as_owner(user, "A team", "")
-
         meeting_name = "A meeting"
-        meeting = MeetingService.create_meeting_for_team_with_id(team.id, meeting_name)
+        meeting = MeetingService.create(self.team.id, meeting_name)
 
-        retrieved_meeting = MeetingService.get_meeting_with_id(meeting.id)
+        retrieved_meeting = MeetingService.get(meeting.id)
 
         self.assertEqual(retrieved_meeting.id, meeting.id)
         self.assertEqual(retrieved_meeting.name, meeting_name)

--- a/mellophone/backend/services/tests/test_team_service.py
+++ b/mellophone/backend/services/tests/test_team_service.py
@@ -3,97 +3,51 @@ from django.test import TestCase
 # from django.db.utils import IntegrityError
 from backend.services.team import TeamService
 from backend.services.user import UserService
+from backend.models import Team
+from backend.exceptions import BadRequestException
 
 
 class TeamServiceTestCase(TestCase):
-    team_service = TeamService()
-    user_service = UserService()
+    def setUp(self):
+        self.user = UserService.create("john@email.com", "hunter2", "John", "Doe")
 
     def test_create_team_for_new_user(self):
         """
         A new user should be able to create a team and be registered as a
         member.
         """
-        user = self.user_service.create_user("john@email.com", "hunter2", "John", "Doe")
-
-        self.assertEqual(
-            len(self.team_service.get_teams_of_user(user)),
-            0,
-            "A new user should not be a member of any teams",
-        )
-
         name = "Glen Eira Band"
         website = "http://gleneiraband.com.au/"
-        team = self.team_service.create_team_with_user_as_owner(user, name, website)
 
-        self.assertEqual(team.name, name, "The team should have a matching name")
-        self.assertEqual(
-            team.website, website, "The team should have a matching website"
-        )
-        self.assertTrue(
-            self.team_service.is_user_in_team_with_id(user, team.id),
-            "The user should be a member of the team they have just created",
-        )
+        # A new team should be created
+        team = TeamService.create_team_with_user_as_owner(self.user, name, website)
+        self.assertEqual(team.name, name)
+        self.assertEqual(team.website, website)
 
-        teams_of_user = self.team_service.get_teams_of_user(user)
+        # The user must be a member of this team
+        teams_of_user = TeamService.get_teams_of_user_with_id(self.user.id)
+        self.assertEqual(len(teams_of_user), 1)
+        self.assertEqual(teams_of_user[0].id, team.id)
 
-        self.assertEqual(
-            len(teams_of_user), 1, "The user should only be a member of their new team"
-        )
-        self.assertEqual(
-            teams_of_user[0].id,
-            team.id,
-            "The team the user is a member of should be the one they created",
-        )
-
-    def test_user_not_in_team(self):
+    def test_create_team_throws_if_no_name(self):
         """
-        Users do not have to be members of a team.
+        Newly-created teams must have a name
         """
-        user_in_team = self.user_service.create_user(
-            "john@email.com", "hunter2", "John", "Doe"
-        )
-        user_not_in_team = self.user_service.create_user(
-            "jane@email.com", "hunter2", "Jane", "Doe"
-        )
+        with self.assertRaises(BadRequestException, msg="Teams must have a name"):
+            TeamService.create_team(name="", website="-")
 
-        name = "Glen Eira Band"
-        website = "http://gleneiraband.com.au/"
-        team = self.team_service.create_team_with_user_as_owner(
-            user_in_team, name, website
-        )
-
-        self.assertTrue(
-            self.team_service.is_user_in_team_with_id(user_in_team, team.id),
-            "The user who created a team should be a member",
-        )
-        self.assertFalse(
-            self.team_service.is_user_in_team_with_id(user_not_in_team, team.id),
-            "Another user who is not in the team should not be a member",
-        )
 
     def test_get_team(self):
         """
         Create and retrieve a team.
         """
-        user = self.user_service.create_user("john@email.com", "hunter2", "John", "Doe")
 
         name = "Glen Eira Band"
         website = "http://gleneiraband.com.au/"
-        team = self.team_service.create_team_with_user_as_owner(user, name, website)
+        team = TeamService.create_team_with_user_as_owner(self.user, name, website)
 
-        retrieved_team = self.team_service.get_team_with_id(team.id)
+        retrieved_team = TeamService.get(team.id)
 
-        self.assertEqual(
-            team.id, retrieved_team.id, "The retrieved team should have the expected ID"
-        )
-        self.assertEqual(
-            team.name,
-            retrieved_team.name,
-            "The retrieved team should have the expected name",
-        )
-        self.assertEqual(
-            team.website,
-            retrieved_team.website,
-            "The retrieved team should have the expected website",
-        )
+        self.assertEqual(team.id, retrieved_team.id)
+        self.assertEqual(team.name, retrieved_team.name)
+        self.assertEqual(team.website, retrieved_team.website)

--- a/mellophone/backend/services/tests/test_user_service.py
+++ b/mellophone/backend/services/tests/test_user_service.py
@@ -1,16 +1,11 @@
 from django.test import TestCase
 from backend.models import User
-from backend.services.user import (
-    UserService,
-    EmailAlreadyInUseException,
-    InvalidUserDetailsException,
-)
+from backend.services.user import UserService
+from backend.exceptions import BadRequestException
 
 
 class UserServiceTestCase(TestCase):
-    user_service = UserService()
-
-    def test_create_user(self):
+    def test_create(self):
         """
         A user can be created.
         """
@@ -18,45 +13,28 @@ class UserServiceTestCase(TestCase):
         password = "hunter2"
         first_name = "John"
         last_name = "Doe"
+        user = UserService.create(email, password, first_name, last_name)
 
-        self.assertFalse(
-            User.objects.filter(email=email).exists(),
-            "The new user should not already exist",
-        )
+        self.assertNotEqual(user, None)
+        self.assertEqual(user.email, email)
+        self.assertEqual(user.first_name, first_name)
+        self.assertEqual(user.last_name, last_name)
 
-        user = self.user_service.create_user(email, password, first_name, last_name)
-
-        self.assertEqual(
-            User.objects.filter(email=email).count(),
-            1,
-            "A single user should have been created",
-        )
-        self.assertNotEqual(
-            user, None, "UserService.create_user() must return a user instance"
-        )
-        self.assertEqual(user.email, email, "The user must have a matching email")
-        self.assertEqual(
-            user.first_name, first_name, "The user must have a matching first name"
-        )
-        self.assertEqual(
-            user.last_name, last_name, "The user must have a matching last name"
-        )
-
-    def test_cannot_create_user_with_taken_email(self):
+    def test_cannot_create_with_taken_email(self):
         """
         If an email is in use by another user when signing up, it should throw
         an error.
         """
         email = "taken@email.com"
 
-        UserService.create_user(email, "-", "-", "-")
+        UserService.create(email, "-", "-", "-")
 
-        def create_user_when_already_exists():
-            UserService.create_user(email, "-", "-", "-")
+        with self.assertRaises(
+            BadRequestException, msg="The email {} is already in use".format(email)
+        ):
+            UserService.create(email, "-", "-", "-")
 
-        self.assertRaises(EmailAlreadyInUseException, create_user_when_already_exists)
-
-    def test_cannot_create_user_with_empty_fields(self):
+    def test_cannot_create_with_empty_fields(self):
         """
         All fields must be non-empty strings, otherwise the user creation
         should fail.
@@ -66,19 +44,13 @@ class UserServiceTestCase(TestCase):
         first_name = "John"
         last_name = "Doe"
 
+        with self.assertRaises(BadRequestException, msg="An email must be supplied"):
+            UserService.create("", password, first_name, last_name)
+        with self.assertRaises(BadRequestException, msg="A password must be supplied"):
+            UserService.create(email, "", first_name, last_name)
         with self.assertRaises(
-            InvalidUserDetailsException, msg="An email must be supplied"
+            BadRequestException, msg="A first name must be supplied"
         ):
-            UserService.create_user("", password, first_name, last_name)
-        with self.assertRaises(
-            InvalidUserDetailsException, msg="A password must be supplied"
-        ):
-            UserService.create_user(email, "", first_name, last_name)
-        with self.assertRaises(
-            InvalidUserDetailsException, msg="A first name must be supplied"
-        ):
-            UserService.create_user(email, password, "", last_name)
-        with self.assertRaises(
-            InvalidUserDetailsException, msg="A last name must be supplied"
-        ):
-            UserService.create_user(email, password, first_name, "")
+            UserService.create(email, password, "", last_name)
+        with self.assertRaises(BadRequestException, msg="A last name must be supplied"):
+            UserService.create(email, password, first_name, "")

--- a/mellophone/backend/services/user.py
+++ b/mellophone/backend/services/user.py
@@ -1,4 +1,5 @@
 from django.contrib.auth.models import User
+from backend.exceptions import BadRequestException
 
 
 class UserService:
@@ -11,35 +12,25 @@ class UserService:
     """
 
     @staticmethod
-    def create_user(email, password, first_name, last_name):
-        """
-        Creates a new user, with a username matching their email.
-        """
+    def create(email, password, first_name, last_name):
         if email == "":
-            raise InvalidUserDetailsException("An email must be supplied.")
+            raise BadRequestException("An email must be supplied")
         if password == "":
-            raise InvalidUserDetailsException("A password must be supplied.")
+            raise BadRequestException("A password must be supplied")
         if first_name == "":
-            raise InvalidUserDetailsException("A first name must be supplied.")
+            raise BadRequestException("A first name must be supplied")
         if last_name == "":
-            raise InvalidUserDetailsException("A last name must be supplied.")
+            raise BadRequestException("A last name must be supplied")
 
         if User.objects.filter(email=email).exists():
             message = 'The email "{}" is not available.'.format(email)
-            raise EmailAlreadyInUseException(message)
+            raise BadRequestException(message)
 
         return User.objects.create_user(
-            email,  # username is same as email
-            email,  # email
-            password,
+            username=email,  # username is same as email
+            email=email,  # email
+            password=password,
             first_name=first_name,
             last_name=last_name,
         )
 
-
-class InvalidUserDetailsException(Exception):
-    pass
-
-
-class EmailAlreadyInUseException(Exception):
-    pass

--- a/mellophone/backend/urls.py
+++ b/mellophone/backend/urls.py
@@ -12,6 +12,7 @@ from backend.controllers.identity import IdentityController
 from backend.controllers.team import TeamController
 from backend.controllers.meeting import MeetingController
 from backend.views import GenericViews
+from backend.exceptions import BadRequestException, ForbiddenException,AuthenticationRequiredException
 
 index_controller = IndexController()
 identity_controller = IdentityController()
@@ -29,15 +30,22 @@ def route(path, get=None, post=None, put=None, delete=None):
     """
 
     def handler(request):
-        method = request.method
-        if method == "GET" and get is not None:
-            return get(request)
-        if method == "POST" and post is not None:
-            return post(request)
-        if method == "PUT" and put is not None:
-            return put(request)
-        if method == "DELETE" and delete is not None:
-            return delete(request)
+        try:
+            if request.method == "GET" and get is not None:
+                return get(request)
+            if request.method == "POST" and post is not None:
+                return post(request)
+            if request.method == "PUT" and put is not None:
+                return put(request)
+            if request.method == "DELETE" and delete is not None:
+                return delete(request)
+        except BadRequestException as error:
+            return GenericViews.invalid_request_response(request, error)
+        except ForbiddenException as error:
+            return GenericViews.forbidden_response(request, error)
+        except AuthenticationRequiredException as error:
+            return GenericViews.authentication_required_response(request, error)
+
         return GenericViews.not_found_response(request)
 
     return re_path(path, handler)

--- a/mellophone/backend/views.py
+++ b/mellophone/backend/views.py
@@ -52,3 +52,10 @@ class GenericViews:
         if error is None:
             error = "Invalid request"
         return JsonResponse({"error": str(error)}, status=400)
+
+    @staticmethod
+    def internal_error_response(request):
+        """
+        Used if an unforeseen error is encountered while processing a request.
+        """
+        return JsonResponse({"error": "An internal error occured"}, status=500)


### PR DESCRIPTION
Services now throw generic errors that correspond to 4XX responses. The status of the error can communicate the general issue, while the message itself gives more actionable/understandable information. It also means a catch-all handler can intercept errors when handling a request.

Most model-focused services now have general get/create methods. Further functionality is added on a per-service basis.

Tests have been cleaned up, using the `setUp()` method for repititive logic, such as creating mock users and teams.