### PR TITLE
Allow DB connections in CI to have no password

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,6 +13,7 @@ variables:
   POSTGRES_USER: "postgres"
   POSTGRES_PASSWORD: ""
   POSTGRES_HOST: "postgres"
+  POSTGRES_HOST_AUTH_METHOD: "trust"
   DJANGO_SECRET_KEY: "DJANGO_SECRET_KEY"
   DJANGO_SETTINGS_MODULE: "mellophone.settings_local"
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![](https://gitlab.com/nchlswhttkr/mellophone/badges/master/pipeline.svg?style=flat-square)](https://gitlab.com/nchlswhttkr/mellophone/pipelines)
 
-! :warning: While I haven't had time to work on Mellophone lately, there's still plenty of cool things to dig into!
+> :warning: While I haven't had time to work on Mellophone lately, there's still plenty of cool things to dig into!
 
 :trumpet: :trumpet: :trumpet:
 


### PR DESCRIPTION
So the PostgreSQL Docker image updated and was yelling when no password is provided by default. Fortunately, it can be disabled by environment variables.